### PR TITLE
fix: remove staticDirs

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,6 @@
     "description": "A plugin for NodeBB to take file uploads and store them on S3 updated for 1.0",
     "url": "https://github.com/LewisMcMahon/nodebb-plugin-s3-uploads",
     "library": "./index.js",
-    "staticDirs": {
-        "s3": "public"
-    },
     "hooks": [
         { "hook": "static:app.load", "method": "load"},
         { "hook": "action:plugin.activate", "method": "activate"},


### PR DESCRIPTION
This directory isn't used and just causes a warning (which was an error in older NodeBB versions!) about a missing path. It's a relic from a ton of forks with changes that somehow slipped through all the way here (it WAS the public path in early versions but someone along the way changed it to `static` instead od `public` but didn't change `plugin.json`).

The warnings:
```APL
warn: [plugins] File not found: /var/www/stfu.waw.pl/html/forum/node_modules/@nodebb-community/nodebb-plugin-s3-uploads-updated/public (Ignoring)
warn: [plugins/@nodebb-community/nodebb-plugin-s3-uploads-updated] Invalid mapped path specified: s3 => public
warn: [plugins] File not found: /var/www/stfu.waw.pl/html/forum/node_modules/@nodebb-community/nodebb-plugin-s3-uploads-updated/public (Ignoring)
```

Community forum reference: https://community.nodebb.org/topic/16629/image-upload-plugin-in-nodebb-2-x

